### PR TITLE
[MRG] Add CORS support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ flask-uploads = {version = ">0.2.0"}
 SQLAlchemy = {version = ">1.2.0"}
 flask_sqlalchemy  = {version = ">=2.3.1"}
 marshmallow-sqlalchemy = "*"
+flask_cors = "*"
 
 [dev-packages]
 pylint = {version = ">1.8.3"}

--- a/persephone_api/app.py
+++ b/persephone_api/app.py
@@ -10,6 +10,8 @@ from .extensions import db
 from .settings import ProdConfig
 from .upload_config import configure_uploads
 
+from flask_cors import CORS
+
 def create_app(config_object=ProdConfig):
     """An application factory, as explained here: http://flask.pocoo.org/docs/patterns/appfactories/.
     :param config_object: The configuration object to use.
@@ -24,6 +26,10 @@ def create_app(config_object=ProdConfig):
 
     register_extensions(app)
     configure_uploads(app, base_upload_path=os.path.join(os.getcwd(), 'user_uploads'))
+
+    if config_object.ENABLE_CORS:
+        CORS(app)
+
     return app
 
 def register_swagger_api(connexion_flask_app) -> None:

--- a/persephone_api/settings.py
+++ b/persephone_api/settings.py
@@ -10,6 +10,9 @@ class Config:
     PROJECT_ROOT = os.path.abspath(os.path.join(APP_DIR, os.pardir))
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+    # Enable Cross-Origin Resource Sharing headers
+    ENABLE_CORS = False
+
 
 class ProdConfig(Config):
     """Production configuration."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask-uploads
 sqlalchemy>1.2
 flask_sqlalchemy
 marshmallow-sqlalchemy
+flask_cors


### PR DESCRIPTION
Adds support for [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS), so that this API can be used as the backend on modern browser.

I've set it to be disabled by default in the config.