### PR TITLE
[MRG] Verify responses against API spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+pipfileenv/
 
 # Spyder project settings
 .spyderproject
@@ -109,3 +110,10 @@ venv.bak/
 
 # Vim files
 *.swp
+
+# Vagrant VM
+.vagrant/
+
+
+# Database
+dev.db

--- a/persephone_api/api_endpoints/audio.py
+++ b/persephone_api/api_endpoints/audio.py
@@ -5,7 +5,7 @@ This deals with the API access for audio files uploading/downloading.
 import flask_uploads
 
 from ..extensions import db
-from ..db_models import Audio
+from ..db_models import Audio, FileMetaData
 from ..upload_config import audio_files, uploads_url_base
 from ..serialization import AudioSchema
 
@@ -17,7 +17,8 @@ def post(audioFile):
         return "Invalid upload format, must be an audio file", 415
     else:
         file_url = uploads_url_base + 'audio_uploads/' + filename
-        current_file = Audio(filename=filename, url=file_url)
+        metadata = FileMetaData(path=file_url, name=filename)
+        current_file = Audio(file_info=metadata, url=file_url)
         db.session.add(current_file)
         db.session.commit()
 

--- a/persephone_api/api_endpoints/corpus.py
+++ b/persephone_api/api_endpoints/corpus.py
@@ -6,6 +6,7 @@ import logging
 import os
 from pathlib import Path
 from shutil import copyfile
+from typing import Set
 import uuid
 import zipfile
 
@@ -14,8 +15,9 @@ from persephone.corpus import Corpus
 import sqlalchemy
 
 from ..extensions import db
-from ..db_models import DBcorpus, TestingDataSet, TrainingDataSet, ValidationDataSet, Label, CorpusLabelSet
-from ..serialization import CorpusSchema
+from ..db_models import (DBcorpus, TestingDataSet, TrainingDataSet, ValidationDataSet,
+                         Label, CorpusLabelSet)
+from ..serialization import CorpusSchema, LabelSchema
 
 
 logger = logging.getLogger(__name__)
@@ -70,14 +72,14 @@ def create_prefixes(audio_uploads_path: Path, transcription_uploads_path: Path, 
             pf.write(os.linesep)
     return prefixes
 
-def labels_set(corpus: DBcorpus) -> set:
+def labels_set(corpus: DBcorpus) -> Set[Label]:
     """Retrieve the set of labels associated with a corpus.
-    
     Given a corpus stored in the DB this will fetch the label set defined by that corpus."""
+
     labels_query = db.session.query(CorpusLabelSet).filter_by(corpus_id=corpus.id)
     labels = set()
     for l in labels_query.all():
-        labels.add(l.label.label)
+        labels.add(l.label)
     return labels
 
 def create_corpus_file_structure(audio_uploads_path: Path, transcription_uploads_path: Path,
@@ -232,9 +234,12 @@ def get_label_set(corpusID):
     """Get the label set for a corpus with the given ID"""
     existing_corpus = DBcorpus.query.get_or_404(corpusID)
     corpus_data = fix_corpus_format(CorpusSchema().dump(existing_corpus).data)
-    labels = labels_set(existing_corpus)
 
-    return {"corpus": corpus_data, "labels": list(labels) }, 200
+    results = []
+    for label in labels_set(existing_corpus):
+        results.append(LabelSchema().dump(label).data)
+
+    return {"corpus": corpus_data, "labels": results }, 200
 
 def preprocess(corpusID):
     """Preprocess a corpus"""

--- a/persephone_api/api_endpoints/corpus.py
+++ b/persephone_api/api_endpoints/corpus.py
@@ -150,7 +150,12 @@ def get(corpusID):
 
 def post(corpusInfo):
     """Create a DBcorpus"""
-    max_samples = corpusInfo.get('max_samples', None)
+    INT64_MAX =  2^63 - 1 # Largest size that the 64bit integer value for the max_samples
+                          # can contain, this exists because the API will complain if a None
+                          # is returned, so we get much the same behavior by making the default
+                          # value the integer max value
+
+    max_samples = corpusInfo.get('max_samples', INT64_MAX)
     current_corpus = DBcorpus(
         name=corpusInfo['name'],
         label_type=corpusInfo['label_type'],

--- a/persephone_api/api_endpoints/corpus.py
+++ b/persephone_api/api_endpoints/corpus.py
@@ -42,7 +42,7 @@ def create_prefixes(audio_uploads_path: Path, transcription_uploads_path: Path, 
     count = 0
     for data in prefix_information:
         count += 1
-        label_filename = data.utterance.transcription.filename
+        label_filename = data.utterance.transcription.file_info.name
 
         # using the prefix of the label file to specify the prefix
         prefix, extension = os.path.splitext(label_filename)
@@ -55,7 +55,7 @@ def create_prefixes(audio_uploads_path: Path, transcription_uploads_path: Path, 
         copyfile(str(label_src_path), str(label_dest_path))
 
         # copy audio to "/wav" directory
-        audio_filename = data.utterance.audio.filename
+        audio_filename = data.utterance.audio.file_info.name
         audio_src_path = audio_uploads_path / audio_filename
         audio_dest_path = base_path / "wav" / (cleaned_prefix+".wav")
         copyfile(str(audio_src_path), str(audio_dest_path))

--- a/persephone_api/api_endpoints/model.py
+++ b/persephone_api/api_endpoints/model.py
@@ -179,7 +179,7 @@ def transcribe(modelID, audioID):
 
     # putting features into the existing corpus path for now
     corpus_path = Path(flask.current_app.config['CORPUS_PATH']) / current_model.corpus.filesystem_path
-    audio_path = audio_uploads_path / audio_info.filename
+    audio_path = audio_uploads_path / audio_info.file_info.name
 
     labels = labels_set(current_model.corpus)
 

--- a/persephone_api/api_endpoints/model.py
+++ b/persephone_api/api_endpoints/model.py
@@ -181,7 +181,7 @@ def transcribe(modelID, audioID):
     corpus_path = Path(flask.current_app.config['CORPUS_PATH']) / current_model.corpus.filesystem_path
     audio_path = audio_uploads_path / audio_info.file_info.name
 
-    labels = labels_set(current_model.corpus)
+    labels = [item.label for item in labels_set(current_model.corpus)]
 
     results = model.decode(
         model_checkpoint_path, [audio_path],

--- a/persephone_api/api_endpoints/transcription.py
+++ b/persephone_api/api_endpoints/transcription.py
@@ -9,8 +9,12 @@ from ..db_models import Transcription, FileMetaData
 from ..upload_config import text_files, uploads_url_base
 from ..serialization import TranscriptionSchema
 
+def post():
+    """Create a transcription from a POST request that contains the
+    transcription information in a UTF-8 encoded string"""
+    raise NotImplementedError
 
-def post(transcriptionFile):
+def from_file(transcriptionFile):
     """handle POST request for transcription file"""
     try:
         filename = text_files.save(transcriptionFile)
@@ -19,11 +23,11 @@ def post(transcriptionFile):
     else:
         file_url = uploads_url_base + 'text_uploads/' + filename
         metadata = FileMetaData(path=file_url, name=filename)
-        current_file = Transcription(file_info=metadata, url=file_url)
-        db.session.add(current_file)
+        current_transcription = Transcription(file_info=metadata, url=file_url, name=filename)
+        db.session.add(current_transcription)
         db.session.commit()
 
-    result = TranscriptionSchema().dump(current_file).data
+    result = TranscriptionSchema().dump(current_transcription).data
     return result, 201
 
 def get(transcriptionID):

--- a/persephone_api/api_endpoints/transcription.py
+++ b/persephone_api/api_endpoints/transcription.py
@@ -5,7 +5,7 @@ This deals with the API access for transcription files uploading/downloading.
 import flask_uploads
 
 from ..extensions import db
-from ..db_models import Transcription
+from ..db_models import Transcription, FileMetaData
 from ..upload_config import text_files, uploads_url_base
 from ..serialization import TranscriptionSchema
 
@@ -18,7 +18,8 @@ def post(transcriptionFile):
         return "Invalid upload format, must be a text file", 415
     else:
         file_url = uploads_url_base + 'text_uploads/' + filename
-        current_file = Transcription(filename=filename, url=file_url)
+        metadata = FileMetaData(path=file_url, name=filename)
+        current_file = Transcription(file_info=metadata, url=file_url)
         db.session.add(current_file)
         db.session.commit()
 

--- a/persephone_api/api_spec.yaml
+++ b/persephone_api/api_spec.yaml
@@ -465,10 +465,13 @@ definitions:
     type: "object"
     properties:
       id:
-        type: "integer"
-        format: "int64"
+        $ref: "#/definitions/audioURI"
       file_info:
         $ref: "#/definitions/fileInformation"
+  audioURI:
+    description: "URI for audio objects"
+    type: "integer"
+    format: "int64"
   backendInformation:
     type: "object"
     required:
@@ -633,8 +636,7 @@ definitions:
     - "name"
     properties:
       id:
-        type: "integer"
-        format: "int64"
+        $ref: "#/definitions/transcriptionURI"
       name:
         type: "string"
         example: "transcription.txt"
@@ -643,6 +645,10 @@ definitions:
         description: "Flag if this file was generated manually. Useful for keeping track of training files"
       file_info:
         $ref: "#/definitions/fileInformation"
+  transcriptionURI:
+    description: "URI for transcription objects"
+    type: "integer"
+    format: "int64"
   utteranceInformation:
     type: "object"
     properties:
@@ -650,9 +656,9 @@ definitions:
         type: "integer"
         format: "int64"
       audio:
-        $ref: "#/definitions/audioFileInformation"
+        $ref: "#/definitions/audioURI"
       transcription:
-        $ref: "#/definitions/transcriptionInformation"
+        $ref: "#/definitions/transcriptionURI"
     required:
     - "audio"
     - "transcription"

--- a/persephone_api/api_spec.yaml
+++ b/persephone_api/api_spec.yaml
@@ -408,13 +408,13 @@ definitions:
   audioFileInformation:
     type: "object"
     required:
-    - "name"
+    - "filename"
     - "fileURL"
     properties:
       id:
         type: "integer"
         format: "int64"
-      name:
+      filename:
         type: "string"
         example: "recording_123.wav"
       fileURL:
@@ -609,3 +609,16 @@ definitions:
     required:
     - "audio"
     - "transcription"
+  fileInformation:
+    type: "object"
+    properties:
+      id:
+        type: "string"
+        description: "Unique ID for this file"
+      name:
+        type: "string"
+        description: "The name of this file"
+      created_at:
+        type: "string"
+        format: "date-time"
+        description: "The time this file was created at"

--- a/persephone_api/api_spec.yaml
+++ b/persephone_api/api_spec.yaml
@@ -351,7 +351,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: "#/definitions/transcriptionFileInformation"
+              $ref: "#/definitions/transcriptionInformation"
     post:
       summary: "Upload an transcription file"
       tags:
@@ -367,13 +367,13 @@ paths:
         201:
           description: success
           schema:
-            $ref: "#/definitions/transcriptionFileInformation"
+            $ref: "#/definitions/transcriptionInformation"
         415:
           description: "Bad filetype"
 
   /transcription/{transcriptionID}:
     get:
-      summary: "Get information about an uploaded transcription file"
+      summary: "Get information about a transcriptions"
       tags:
         - getObject
       produces:
@@ -389,7 +389,7 @@ paths:
         200:
           description: success
           schema:
-            $ref: "#/definitions/transcriptionFileInformation"
+            $ref: "#/definitions/transcriptionInformation"
         404:
           description: "Transcription not found"
 
@@ -632,11 +632,10 @@ definitions:
       URL:
         description: "URL path to check on task progress"
         type: "string"
-  transcriptionFileInformation:
+  transcriptionInformation:
     type: "object"
     required:
     - "name"
-    - "fileURL"
     properties:
       id:
         type: "integer"
@@ -647,9 +646,8 @@ definitions:
       manuallyGenerated:
         type: boolean
         description: "Flag if this file was generated manually. Useful for keeping track of training files"
-      fileURL:
-        type: "string"
-        example: "/path/to/file/transcription.txt"
+      file_info:
+        $ref: "#/definitions/fileInformation"
   utteranceInformation:
     type: "object"
     properties:
@@ -659,7 +657,7 @@ definitions:
       audio:
         $ref: "#/definitions/audioFileInformation"
       transcription:
-        $ref: "#/definitions/transcriptionFileInformation"
+        $ref: "#/definitions/transcriptionInformation"
     required:
     - "audio"
     - "transcription"

--- a/persephone_api/api_spec.yaml
+++ b/persephone_api/api_spec.yaml
@@ -463,19 +463,12 @@ paths:
 definitions:
   audioFileInformation:
     type: "object"
-    required:
-    - "filename"
-    - "fileURL"
     properties:
       id:
         type: "integer"
         format: "int64"
-      filename:
-        type: "string"
-        example: "recording_123.wav"
-      fileURL:
-        type: "string"
-        example: "/path/to/file/recording_123.wav"
+      file_info:
+        $ref: "#/definitions/fileInformation"
   backendInformation:
     type: "object"
     required:

--- a/persephone_api/api_spec.yaml
+++ b/persephone_api/api_spec.yaml
@@ -667,7 +667,8 @@ definitions:
     type: "object"
     properties:
       id:
-        type: "string"
+        type: "integer"
+        format: "int64"
         description: "Unique ID for this file"
       name:
         type: "string"

--- a/persephone_api/api_spec.yaml
+++ b/persephone_api/api_spec.yaml
@@ -525,14 +525,24 @@ definitions:
           testing:
             $ref: "#/definitions/utteranceGroup"
             description: "Utterances in testing set"
-  labelType:
-    type: "string"
-    description: "The type of the labels"
-    example: "phonemes"
   featureType:
     type: "string"
     description: "The type of the features"
     example: "fbank"
+  fileInformation:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+        description: "Unique ID for this file"
+      name:
+        type: "string"
+        description: "The name of this file"
+      created_at:
+        type: "string"
+        format: "date-time"
+        description: "The time this file was created at"
   IDarray:
     type: "array"
     items:
@@ -557,6 +567,10 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/label"
+  labelType:
+    type: "string"
+    description: "The type of the labels"
+    example: "phonemes"
 
   modelInformation:
     type: "object"
@@ -664,17 +678,3 @@ definitions:
     description: "URI for utterance objects"
     type: "integer"
     format: "int64"
-  fileInformation:
-    type: "object"
-    properties:
-      id:
-        type: "integer"
-        format: "int64"
-        description: "Unique ID for this file"
-      name:
-        type: "string"
-        description: "The name of this file"
-      created_at:
-        type: "string"
-        format: "date-time"
-        description: "The time this file was created at"

--- a/persephone_api/api_spec.yaml
+++ b/persephone_api/api_spec.yaml
@@ -352,7 +352,9 @@ paths:
             type: array
             items:
               $ref: "#/definitions/transcriptionInformation"
+  /transcription/fromFile:
     post:
+      operationId: persephone_api.api_endpoints.transcription.from_file
       summary: "Upload an transcription file"
       tags:
         - createObject

--- a/persephone_api/api_spec.yaml
+++ b/persephone_api/api_spec.yaml
@@ -517,19 +517,13 @@ definitions:
         description: "How utterances are assigned to datasets for use in training the model"
         properties:
           training:
-            type: array
-            items:
-              $ref: "#/definitions/utteranceInformation"
+            $ref: "#/definitions/utteranceGroup"
             description: "Utterances in training set"
           validation:
-            type: array
-            items:
-              $ref: "#/definitions/utteranceInformation"
+            $ref: "#/definitions/utteranceGroup"
             description: "Utterances in validation set"
           testing:
-            type: array
-            items:
-              $ref: "#/definitions/utteranceInformation"
+            $ref: "#/definitions/utteranceGroup"
             description: "Utterances in testing set"
   labelType:
     type: "string"
@@ -649,12 +643,16 @@ definitions:
     description: "URI for transcription objects"
     type: "integer"
     format: "int64"
+  utteranceGroup:
+    description: "Specify a group of utterances. This is needed to define a partition of test/train/valid data sets for model training."
+    type: "array"
+    items:
+      $ref: "#/definitions/utteranceURI"
   utteranceInformation:
     type: "object"
     properties:
       id:
-        type: "integer"
-        format: "int64"
+        $ref: "#/definitions/utteranceURI"
       audio:
         $ref: "#/definitions/audioURI"
       transcription:
@@ -662,6 +660,10 @@ definitions:
     required:
     - "audio"
     - "transcription"
+  utteranceURI:
+    description: "URI for utterance objects"
+    type: "integer"
+    format: "int64"
   fileInformation:
     type: "object"
     properties:

--- a/persephone_api/app.py
+++ b/persephone_api/app.py
@@ -28,7 +28,11 @@ def create_app(config_object=ProdConfig):
 
 def register_swagger_api(connexion_flask_app) -> None:
     """Take a connexion FlaskApp and register swagger API"""
-    connexion_flask_app.add_api('api_spec.yaml', resolver=RestyResolver('persephone_api.api_endpoints'))
+    connexion_flask_app.add_api(
+        'api_spec.yaml',
+        resolver=RestyResolver('persephone_api.api_endpoints'),
+        validate_responses=True
+    )
 
 def register_extensions(app) -> None:
     """Register Flask extensions."""

--- a/persephone_api/db_models.py
+++ b/persephone_api/db_models.py
@@ -30,13 +30,15 @@ class Audio(db.Model):
     __tablename__ = 'audio'
 
     id = db.Column(db.Integer, primary_key=True)
-    filename = db.Column(db.String)
     url = db.Column(db.String)
+
+    file_info = db.relationship('FileMetaData')
+    file_info_id = db.Column(db.Integer, db.ForeignKey('file_metadata.id'))
 
     in_utterances = db.relationship("DBUtterance", cascade="all, delete-orphan")
 
     def __repr__(self):
-        return "<Audio(filename={}, url={})>".format(self.filename, self.url)
+        return "<Audio(file_info={}, url={})>".format(self.file_info, self.url)
 
 
 class Transcription(db.Model):

--- a/persephone_api/db_models.py
+++ b/persephone_api/db_models.py
@@ -1,3 +1,5 @@
+import datetime
+
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlite3 import Connection as SQLite3Connection
@@ -10,6 +12,13 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
         cursor = dbapi_connection.cursor()
         cursor.execute("PRAGMA foreign_keys=ON;")
         cursor.close()
+
+class FileMetaData(db.Model):
+    """Database ORM definition for file metadata"""
+    __tablename__ = 'file_metadata'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String)
+    created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow)
 
 class Audio(db.Model):
     """Database ORM definition for Audio files"""

--- a/persephone_api/db_models.py
+++ b/persephone_api/db_models.py
@@ -45,6 +45,7 @@ class Transcription(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     url = db.Column(db.String)
+    name = db.Column(db.String)
 
     in_utterances = db.relationship("DBUtterance", cascade="all, delete-orphan")
 

--- a/persephone_api/db_models.py
+++ b/persephone_api/db_models.py
@@ -18,7 +18,12 @@ class FileMetaData(db.Model):
     __tablename__ = 'file_metadata'
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String)
+    path = db.Column(db.String)
     created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow)
+    def __repr__(self):
+        return "<FileMetaData(name={}, path={}, created_at={})>".format(
+            self.name, self.path, self.created_at)
+
 
 class Audio(db.Model):
     """Database ORM definition for Audio files"""
@@ -39,13 +44,15 @@ class Transcription(db.Model):
     __tablename__ = 'transcription'
 
     id = db.Column(db.Integer, primary_key=True)
-    filename = db.Column(db.String)
     url = db.Column(db.String)
 
     in_utterances = db.relationship("DBUtterance", cascade="all, delete-orphan")
 
+    file_info = db.relationship('FileMetaData')
+    file_info_id = db.Column(db.Integer, db.ForeignKey('file_metadata.id'))
+
     def __repr__(self):
-        return "<Transcription(filename={}, url={})>".format(self.filename, self.url)
+        return "<Transcription(file_info={}, url={})>".format(self.file_info, self.url)
 
 
 class DBUtterance(db.Model):

--- a/persephone_api/serialization.py
+++ b/persephone_api/serialization.py
@@ -34,6 +34,7 @@ class CorpusSchema(ModelSchema):
         model = db_models.DBcorpus
 
 class TranscriptionModelSchema(ModelSchema):
+    corpusID = fields.Int(attribute="corpus_id")
     class Meta:
         model = db_models.TranscriptionModel
 

--- a/persephone_api/serialization.py
+++ b/persephone_api/serialization.py
@@ -3,8 +3,14 @@ Serialization for data defined in ORM/DB
 """
 
 from marshmallow_sqlalchemy import ModelSchema
+from marshmallow import fields
 
 from . import db_models
+
+class FileInfoSchema(ModelSchema):
+    """Serialization for file information"""
+    class Meta:
+        model = db_models.FileMetaData
 
 class AudioSchema(ModelSchema):
     class Meta:
@@ -12,6 +18,7 @@ class AudioSchema(ModelSchema):
         exclude = ("utterances",)
 
 class TranscriptionSchema(ModelSchema):
+    file_info = fields.Nested("FileInfoSchema")
     class Meta:
         model = db_models.Transcription
         exclude = ("utterances",)

--- a/persephone_api/serialization.py
+++ b/persephone_api/serialization.py
@@ -13,6 +13,7 @@ class FileInfoSchema(ModelSchema):
         model = db_models.FileMetaData
 
 class AudioSchema(ModelSchema):
+    file_info = fields.Nested("FileInfoSchema")
     class Meta:
         model = db_models.Audio
         exclude = ("utterances",)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,7 @@ def upload_transcription(client):
         """Create a file with appropriate encoding"""
         data = {'transcriptionFile': (io.BytesIO(transcription_data.encode('utf-8')), filename)}
         return client.post(
-            ('/{}/transcription'.format(API_VERSION)),
+            ('/{}/transcription/fromFile'.format(API_VERSION)),
             data=data,
             content_type='multipart/form-data'
         )

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -131,4 +131,6 @@ def test_corpus_labels(client, create_corpus):
     assert response.status_code == 200
     label_response_data = json.loads(response.data.decode('utf8'))
     assert label_response_data['corpus']['id'] == corpus_id
-    assert set(label_response_data['labels']) == expected_labels
+    assert len(label_response_data['labels']) == 3
+    labels_found = set([item["label"] for item in label_response_data['labels']])
+    assert labels_found == expected_labels

--- a/tests/test_train_tiny_yongning_na.py
+++ b/tests/test_train_tiny_yongning_na.py
@@ -27,7 +27,7 @@ def test_tiny(client):
         with open(os.path.join(path, filename), "rb") as transcription_file:
             data = {'transcriptionFile': (transcription_file, filename)}
             response = client.post(
-                ('/v0.1/transcription'),
+                ('/v0.1/transcription/fromFile'),
                 data=data,
                 content_type='multipart/form-data'
             )

--- a/tests/test_transcription_endpoint.py
+++ b/tests/test_transcription_endpoint.py
@@ -4,7 +4,7 @@ def test_transcription_uploads_endpoint(client):
     phonemes = "ɖ ɯ ɕ i k v̩"
     data = {'transcriptionFile': (io.BytesIO(phonemes.encode('utf-8')), 'test_transcription_file.phonemes')}
     response = client.post(
-        ('/v0.1/transcription'),
+        ('/v0.1/transcription/fromFile'),
         data=data,
         content_type='multipart/form-data'
     )

--- a/tests/test_utterance_endpoint.py
+++ b/tests/test_utterance_endpoint.py
@@ -41,7 +41,7 @@ def test_duplicate_utterance(client):
     phonemes = "ɖ ɯ ɕ i k v̩"
     data = {'transcriptionFile': (io.BytesIO(phonemes.encode('utf-8')), 'test_transcription_file.phonemes')}
     response = client.post(
-        ('/v0.1/transcription'),
+        ('/v0.1/transcription/fromFile'),
         data=data,
         content_type='multipart/form-data'
     )


### PR DESCRIPTION
Verifying the response format from requests against the API specification. Fix bugs found from this verification.

- [x] Validate responses vs spec, closes #99
- [x] Fix response format of audio upload endpoint, closes #106
- [x] Fix response format for transcription upload endpoint, closes #107 
- [x] Fix response format for utterance creation endpoint, closes #118 
- [x] Change corpus POST endpoint response such that `max_samples` parameter is always an int64. closes #119 
- [x] Fix missing `corpusID` in serialization of models, closes #120