### PR TITLE
[MRG] Fix issue with corpus partition data

### DIFF
--- a/persephone_api/api_endpoints/corpus.py
+++ b/persephone_api/api_endpoints/corpus.py
@@ -125,13 +125,18 @@ def fix_corpus_format(corpus):
     testing = corpus['testing']
     training = corpus['training']
     validation = corpus['validation']
+
+    testing_ids = [item.utterance_id for item in TestingDataSet.query.filter_by(corpus_id=corpus['id']).all()]
+    training_ids = [item.utterance_id for item in TrainingDataSet.query.filter_by(corpus_id=corpus['id']).all()]
+    validation_ids = [item.utterance_id for item in ValidationDataSet.query.filter_by(corpus_id=corpus['id']).all()]
+
     del fixed_format['testing']
     del fixed_format['training']
     del fixed_format['validation']
     fixed_format['partition'] = {
-        "testing": testing,
-        "training": training,
-        "validation": validation,
+        "testing": testing_ids,
+        "training": training_ids,
+        "validation": validation_ids,
     }
     return fixed_format
 

--- a/persephone_api/serialization.py
+++ b/persephone_api/serialization.py
@@ -32,6 +32,7 @@ class UtteranceSchema(ModelSchema):
 class CorpusSchema(ModelSchema):
     class Meta:
         model = db_models.DBcorpus
+        exclude= ('filesystem_path',)
 
 class TranscriptionModelSchema(ModelSchema):
     """Serialization for a transcription model

--- a/tests/test_corpus_endpoint.py
+++ b/tests/test_corpus_endpoint.py
@@ -78,6 +78,10 @@ def test_corpus_creation(init_database, client, upload_audio, upload_transcripti
     corpus_response_data = json.loads(response.data.decode('utf8'))
     assert corpus_response_data['partition']
 
+    assert corpus_response_data['partition']['testing'] == [utterance_id_a]
+    assert corpus_response_data['partition']['training'] == [utterance_id_b]
+    assert corpus_response_data['partition']['validation'] == [utterance_id_c]
+
 
 def test_corpus_label_regression(init_database, client, upload_audio,
                                  upload_transcription, create_utterance, create_sine):
@@ -168,3 +172,7 @@ def test_corpus_label_regression(init_database, client, upload_audio,
 
     corpus_response_data = json.loads(response.data.decode('utf8'))
     assert corpus_response_data['partition']
+
+    assert corpus_response_data['partition']['testing'] == [utterance_id_a]
+    assert corpus_response_data['partition']['training'] == [utterance_id_b]
+    assert corpus_response_data['partition']['validation'] == [utterance_id_c]


### PR DESCRIPTION
Fix issue where the partition is returning the keys for the partition objects directly and not the array of utterances that are specified in the API spec, closes #161